### PR TITLE
Fixed priviledge mode comparison typo

### DIFF
--- a/libfemto/include/arch/riscv/machine.h
+++ b/libfemto/include/arch/riscv/machine.h
@@ -153,7 +153,7 @@ int pmp_entry_set(unsigned n, uint8_t prot, uint64_t addr, uint64_t len);
  */
 static inline void mode_set_and_jump(unsigned mode, void (*fn)(void))
 {
-    assert(mode <= PRV_U);
+    assert(mode <= PRV_M);
     write_csr(mstatus, set_field(read_csr(mstatus), MSTATUS_MPP, mode));
     write_csr(mepc, fn);
     mret();
@@ -167,7 +167,7 @@ static inline void mode_set_and_jump(unsigned mode, void (*fn)(void))
  */
 static inline void mode_set_and_continue(unsigned mode)
 {
-    assert(mode <= PRV_U);
+    assert(mode <= PRV_M);
     write_csr(mstatus, set_field(read_csr(mstatus), MSTATUS_MPP, mode));
     asm volatile (
         "lla t0, 1f\n"


### PR DESCRIPTION
Hello Michael,
I believe there is a typo in the assertions checking that the mode parameter is valid in `machine.h`, since the parameter is unsigned and the assert checks that it is <= 0. Interestingly enough I encountered the problem trying to switch from machine to supervisor mode and not user mode.

Thanks for these examples and the QEMU model, by the way.
Frédéric